### PR TITLE
Improve retrieve productController unit tests

### DIFF
--- a/testUtils/mockModel.js
+++ b/testUtils/mockModel.js
@@ -1,0 +1,26 @@
+export default mockModel = (model) => {
+  const ops = [
+    'find', 'findOne', 'findById', 'populate',
+    'select', 'skip', 'limit', 'sort',
+  ];
+
+  ops.forEach((method) => {
+    model[method] = jest.fn().mockReturnValue(model);
+  })
+
+  const mockResolvedValue = (method, value) => {
+    if (!ops.includes(method)) {
+      throw new Error(`Method ${method} not found`);
+    }
+    model[method] = jest.fn().mockResolvedValue(value);
+  }
+
+  const mockRejectedValue = (method, error) => {
+    if (!ops.includes(method)) {
+      throw new Error(`Method ${method} not found`);
+    }
+    model[method] = jest.fn().mockRejectedValue(error);
+  }
+
+  return { mockResolvedValue, mockRejectedValue };
+};

--- a/testUtils/mockRequestResponse.js
+++ b/testUtils/mockRequestResponse.js
@@ -1,0 +1,10 @@
+export default mockRequestResponse = (params = {}) => {
+  const req = { params };
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn(),
+    set: jest.fn(),
+    json: jest.fn()
+  };
+  return [req, res];
+};

--- a/testUtils/testDatabaseError.js
+++ b/testUtils/testDatabaseError.js
@@ -1,0 +1,23 @@
+import mockModel from "./mockModel";
+import mockRequestResponse from "./mockRequestResponse";
+
+const testDatabaseError = async (controller, model, method, params) => {
+  const [req, res] = mockRequestResponse(params);
+  const spy = jest.spyOn(console, 'log').mockImplementation();
+  const err = new Error('Database error');
+  mockModel(model).mockRejectedValue(method, err);
+
+  await controller(req, res);
+
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.send).toHaveBeenCalledWith(expect.objectContaining({
+    success: false,
+    message: expect.any(String),
+    error: expect.any(String),
+  }));
+  expect(spy).toHaveBeenCalledTimes(1);
+
+  spy.mockRestore();
+};
+
+export { testDatabaseError };


### PR DESCRIPTION
* Remove internal implementation tests
* Extract helper methods to mock request/response, models, and database errors
* Ensure tests are more resistant to refactoring